### PR TITLE
ci: add custom packageRules in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>terraform-ibm-modules/common-dev-assets:commonRenovateConfig"]
+  "extends": ["local>terraform-ibm-modules/common-dev-assets:commonRenovateConfig"],
+  "packageRules": [
+    {
+      "description": "Use fix as Semantic Commit prefix for all dependency updates in these folders to generate release",
+      "matchPaths": [
+        "examples/ibm-catalog/prepared-system-solution"
+      ],
+      "semanticCommitType": "fix"
+    }
+  ]
 }


### PR DESCRIPTION
### Description

add custom packageRules in renovate.json to use `fix` as Semantic Commit prefix for all dependency updates in specific folders to generate release

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
