### PR TITLE
ci: move image type spec to proper place

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -114,9 +114,8 @@
                                 "diagram": {
                                     "caption": "Full SAP environment provisioned on a secure infrastructure on VPC and extended by Power Virtual Servers",
                                     "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-sap/main/examples/ibm-catalog/prepared-system-solution/layer_deployment_target-STANDARD_FLAVOUR.drawio.svg",
-                                    "metadata": []
+                                    "type": "image/svg+xml"
                                 },
-                                "type": "image/svg+xml",
                                 "description": "SAP on secure Power Virtual Servers builds on the foundation of the 'Secure infrastructure on VPC for regulated industries' and 'Power infrastructure for regulated industries' by completing the deployment of a basic but expandable SAP system landscape. SAP is deployed on Power Virtual Server instances with initial instances of SAP Hana and SAP NetWeaver.\n\nThe network configuration done by the Power infrastructure provides connectivity to NFS servers where storage volumes are created for Hana and Netweaver. Other services such as DNS, NTP and NFS running the Workload VPC are also \nleveraged.\n\nRedundant IBM Cloud Connections provide the network bridge between the IBM Power infrastructure and the IBM VPC. \nAdditional instances of SAP NetWeaver may be configured.\n\nThe resulting SAP landscape leverages the services such as Activity Tracker, Cloud Object Storage, Key Management from the 'Secure infrastructure on VPC for regulated industries' and the network connectivity configuration provided by 'Power infrastructure for regulated industries'. "
                             }
                         ]


### PR DESCRIPTION
### Description

Moved type spec to proper place.  Removed deprecated 'metadata[]'.

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
