### PR TITLE
docs: use templating to auto set version, etc. within usage

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -8,7 +8,7 @@
                     "label": "SAP ready PowerVS",
                     "name": "prepared_system",
                     "working_directory": "examples/ibm-catalog/prepared-system-solution",
-                    "usage": "module \"sap_systems\" {\n  source                    = \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//examples/ibm-catalog/prepared-system-solution?archive=tgz&kind=terraform&name=terraform-ibm-powervs-catalog-powervs-sap-infrastructure&version=1.0.5\"\n  ibmcloud_api_key          = var.ibmcloud_api_key\n  prerequisite_workspace_id = var.prerequisite_workspace_id\n  powervs_zone              = var.powervs_zone\n  prefix                    = var.prefix\n  ssh_private_key           = var.ssh_private_key\n}",
+                    "usage_template": "module \"sap_systems\" {\n  source                    = \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//${{workingDirectory}}?archive=tgz&catalogID=${{catalogID}}&flavor=${{flavor}}&kind=${{kind}}&name=${{name}}&version=${{version}}\"\n  ibmcloud_api_key          = var.ibmcloud_api_key\n  prerequisite_workspace_id = var.prerequisite_workspace_id\n  powervs_zone              = var.powervs_zone\n  prefix                    = var.prefix\n  ssh_private_key           = var.ssh_private_key\n}",
                     "compliance": {
                         "controls": [
                             {

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -8,7 +8,7 @@
                     "label": "SAP ready PowerVS",
                     "name": "prepared_system",
                     "working_directory": "examples/ibm-catalog/prepared-system-solution",
-                    "usage_template": "module \"sap_systems\" {\n  source                    = \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//${{workingDirectory}}?archive=tgz&catalogID=${{catalogID}}&flavor=${{flavor}}&kind=${{kind}}&name=${{name}}&version=${{version}}\"\n  ibmcloud_api_key          = var.ibmcloud_api_key\n  prerequisite_workspace_id = var.prerequisite_workspace_id\n  powervs_zone              = var.powervs_zone\n  prefix                    = var.prefix\n  ssh_private_key           = var.ssh_private_key\n}",
+                    "usage_template": "module \"sap_systems\" {\n  source                    = \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//${{workingDirectory}}?archive=tgz&flavor=${{flavor}}&kind=${{kind}}&name=${{name}}&version=${{version}}\"\n  ibmcloud_api_key          = var.ibmcloud_api_key\n  prerequisite_workspace_id = var.prerequisite_workspace_id\n  powervs_zone              = var.powervs_zone\n  prefix                    = var.prefix\n  ssh_private_key           = var.ssh_private_key\n}",
                     "compliance": {
                         "controls": [
                             {


### PR DESCRIPTION
### Description

Update the catalog manifest, ibm_catalog.json, to use a template for the usage string.   This property causes the `usage` string to be generated dynamically by the catalog but with substitution for catalog id, working directory, etc.



