### PR TITLE
fix: add sleep between e980 and s922 vm to fix satellite error

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-11-02T15:28:02Z",
+  "generated_at": "2023-11-09T07:38:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "3bd02b996f65f3548c1a0b5d93b00bfa7c88341a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 57,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/1
+++ b/1
@@ -1,6 +1,0 @@
-Merge branch 'main' into renovate/ci-dependencies
-# Please enter a commit message to explain why this merge is necessary,
-# especially if it merges an updated upstream into a topic branch.
-#
-# Lines starting with '#' will be ignored, and an empty message aborts
-# the commit.

--- a/1
+++ b/1
@@ -1,0 +1,6 @@
+Merge branch 'main' into renovate/ci-dependencies
+# Please enter a commit message to explain why this merge is necessary,
+# especially if it merges an updated upstream into a topic branch.
+#
+# Lines starting with '#' will be ignored, and an empty message aborts
+# the commit.

--- a/modules/pi-sap-system-type1/README.md
+++ b/modules/pi-sap-system-type1/README.md
@@ -25,7 +25,7 @@ The Power Virtual Server for SAP module automates the following tasks:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.49.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 
 ### Modules
 
@@ -45,6 +45,7 @@ The Power Virtual Server for SAP module automates the following tasks:
 | Name | Type |
 |------|------|
 | [ibm_pi_network.sap_network](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_network) | resource |
+| [time_sleep.wait_1_min](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ### Inputs
 

--- a/modules/pi-sap-system-type1/main.tf
+++ b/modules/pi-sap-system-type1/main.tf
@@ -143,10 +143,15 @@ locals {
   pi_netweaver_instance_storage_config = var.pi_sharefs_instance.enable ? var.pi_netweaver_instance.storage_config : concat(var.pi_netweaver_instance.storage_config, local.pi_netweaver_instance_sapmnt_storage)
 }
 
+resource "time_sleep" "wait_1_min" {
+  create_duration = "60s"
+}
+
 module "pi_netweaver_instance" {
-  source  = "terraform-ibm-modules/powervs-instance/ibm"
-  version = "1.0.2"
-  count   = var.pi_netweaver_instance.instance_count
+  source     = "terraform-ibm-modules/powervs-instance/ibm"
+  version    = "1.0.2"
+  count      = var.pi_netweaver_instance.instance_count
+  depends_on = [time_sleep.wait_1_min]
 
   pi_workspace_guid          = var.pi_workspace_guid
   pi_instance_name           = "${local.pi_netweaver_instance_name}-${count.index + 1}"

--- a/modules/pi-sap-system-type1/version.tf
+++ b/modules/pi-sap-system-type1/version.tf
@@ -10,7 +10,6 @@ terraform {
       source  = "IBM-Cloud/ibm"
       version = ">= 1.49.0"
     }
-
     time = {
       source  = "hashicorp/time"
       version = ">= 0.9.1"

--- a/modules/pi-sap-system-type1/version.tf
+++ b/modules/pi-sap-system-type1/version.tf
@@ -10,10 +10,10 @@ terraform {
       source  = "IBM-Cloud/ibm"
       version = ">= 1.49.0"
     }
-    # tflint-ignore: terraform_unused_required_providers
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 3.2.1"
+
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9.1"
     }
 
   }


### PR DESCRIPTION
### Description

Parallel VM Creation problem:
The problem is with the way the automation is being executed. The same subscription key is always used on the specific account and because these vms are being provisioned at the same time, the registration calls are 1 milisecond time difference. This causes the vms to fail since the key is already in use. A delay of at least 30 seconds should be added between each vm creation to avoid this within each DC.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
