### PR TITLE
fix: upgrade ibm provider version to 1.61.0 which has fix for schematics data source

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -28,7 +28,8 @@
                 "automation",
                 "secure",
                 "server",
-                "networking"
+                "networking",
+                "workspace"
             ],
             "short_description": "Deploy SAP systems on Power Virtual Server with VPC landing zone",
             "long_description": "This deployable architecture is designed to assist you in deploying SAP ERP software landscapes into IBM Cloud on the IBM Power Virtual Server infrastructure. This is the second step in the deployment process for creating a full environment. Before starting this step, you should first deploy 'Power Virtual Server with VPC landing zone'. Once this is completed, you are prepared to start this step.\n\nSAP on Power Virtual Server creates and prepares Power Virtual Server instances for SAP HANA and SAP NetWeaver workloads. After deployment completes, you may (depending on the framework you chose) begin installing SAP on the configured instances or login to your newly created SAP instances directly.",

--- a/modules/pi-sap-system-type1/README.md
+++ b/modules/pi-sap-system-type1/README.md
@@ -24,7 +24,7 @@ The Power Virtual Server for SAP module automates the following tasks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.60.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.61.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 
 ### Modules

--- a/modules/pi-sap-system-type1/version.tf
+++ b/modules/pi-sap-system-type1/version.tf
@@ -8,7 +8,7 @@ terraform {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.60.0"
+      version = ">= 1.61.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/reference-architectures/sap-ready-to-go/deploy-arch-ibm-pvs-sap-ready-to-go.md
+++ b/reference-architectures/sap-ready-to-go/deploy-arch-ibm-pvs-sap-ready-to-go.md
@@ -12,7 +12,7 @@ authors:
   - name: Arnold Beilmann
   - name: Suraj Bharadwaj
 
-version: v1.5.0
+version: v1.5.1
 
 # Whether the reference architecture is published to Cloud Docs production.
 # When set to false, the file is available only in staging. Default is false.
@@ -53,7 +53,7 @@ content-type: reference-architecture
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="1.5.0"}
+{: toc-version="1.5.1"}
 
 The SAP ready PowerVS variation of the Power Virtual Server for SAP HANA creates a basic and expandable SAP system landscape. The variation builds on the foundation of the VPC landing zone and Power Virtual Server with VPC landing zone. PowerVS instances for SAP HANA, SAP NetWeaver, and optionally for shared SAP files are deployed and preconfigured for SAP installation.
 

--- a/reference-architectures/sap-s4hana-bw4hana/deploy-arch-ibm-pvs-sap-s4hana-bw4hana.md
+++ b/reference-architectures/sap-s4hana-bw4hana/deploy-arch-ibm-pvs-sap-s4hana-bw4hana.md
@@ -12,7 +12,7 @@ authors:
   - name: Arnold Beilmann
   - name: Suraj Bharadwaj
 
-version: v1.5.0
+version: v1.5.1
 
 # Whether the reference architecture is published to Cloud Docs production.
 # When set to false, the file is available only in staging. Default is false.
@@ -53,7 +53,7 @@ content-type: reference-architecture
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="1.5.0"}
+{: toc-version="1.5.1"}
 
 'SAP S/4HANA or BW/4HANA' variation of 'Power Virtual Server for SAP HANA' creates a basic and expandable SAP system landscape builds on the foundation of 'Power Virtual Server with VPC landing zone'. PowerVS instances for SAP HANA, SAP NetWeaver, and optionally for shared SAP files are deployed and preconfigured for SAP installation. S/4HANA or BW/4HANA solution is installed based on selected version.
 

--- a/solutions/e2e/README.md
+++ b/solutions/e2e/README.md
@@ -51,14 +51,14 @@ The end to end solution automates the following tasks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.60.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.61.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 
 ### Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_fullstack"></a> [fullstack](#module\_fullstack) | terraform-ibm-modules/powervs-infrastructure/ibm//modules/powervs-vpc-landing-zone | 4.0.0 |
+| <a name="module_fullstack"></a> [fullstack](#module\_fullstack) | terraform-ibm-modules/powervs-infrastructure/ibm//modules/powervs-vpc-landing-zone | 4.0.1 |
 | <a name="module_sap_system"></a> [sap\_system](#module\_sap\_system) | ../../modules/pi-sap-system-type1 | n/a |
 
 ### Resources

--- a/solutions/e2e/main.tf
+++ b/solutions/e2e/main.tf
@@ -7,7 +7,7 @@
 
 module "fullstack" {
   source  = "terraform-ibm-modules/powervs-infrastructure/ibm//modules/powervs-vpc-landing-zone"
-  version = "4.0.0"
+  version = "4.0.1"
 
   providers = { ibm.ibm-is = ibm.ibm-is, ibm.ibm-pi = ibm.ibm-pi }
 

--- a/solutions/e2e/version.tf
+++ b/solutions/e2e/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">=1.60.0"
+      version = ">=1.61.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/solutions/ibm-catalog/sap-ready-to-go/README.md
+++ b/solutions/ibm-catalog/sap-ready-to-go/README.md
@@ -42,7 +42,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.60.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.61.0 |
 
 ### Modules
 

--- a/solutions/ibm-catalog/sap-ready-to-go/version.tf
+++ b/solutions/ibm-catalog/sap-ready-to-go/version.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "=1.60.0"
+      version = "=1.61.0"
     }
   }
 }

--- a/solutions/ibm-catalog/sap-s4hana-bw4hana/README.md
+++ b/solutions/ibm-catalog/sap-s4hana-bw4hana/README.md
@@ -125,7 +125,7 @@ s4hana2022
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.60.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.61.0 |
 
 ### Modules
 

--- a/solutions/ibm-catalog/sap-s4hana-bw4hana/version.tf
+++ b/solutions/ibm-catalog/sap-s4hana-bw4hana/version.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "=1.60.0"
+      version = "=1.61.0"
     }
   }
 }

--- a/solutions/sap-ready-to-go/README.md
+++ b/solutions/sap-ready-to-go/README.md
@@ -36,7 +36,7 @@ The 'sap-ready-to-go' solution automates the following tasks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.49.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.61.0 |
 
 ### Modules
 

--- a/solutions/sap-ready-to-go/version.tf
+++ b/solutions/sap-ready-to-go/version.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">=1.49.0"
+      version = ">=1.61.0"
     }
   }
 }


### PR DESCRIPTION
…ics data source

### Description

upgrade ibm provider version to 1.61.0 which has fix for schematics data source

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
