### PR TITLE
fix: SAP SWPM hdbuserstore config fix

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-09T06:58:51Z",
+  "generated_at": "2024-01-29T11:30:25Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ This repository contains deployable architecture solutions that help in deployin
 * [terraform-ibm-powervs-sap](#terraform-ibm-powervs-sap)
 * [Submodules](./modules)
     * [pi-sap-system-type1](./modules/pi-sap-system-type1)
-* [Examples](./examples)
 * [Contributing](#contributing)
 <!-- END OVERVIEW HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This repository contains deployable architecture solutions that help in deployin
 * [terraform-ibm-powervs-sap](#terraform-ibm-powervs-sap)
 * [Submodules](./modules)
     * [pi-sap-system-type1](./modules/pi-sap-system-type1)
+* [Examples](./examples)
 * [Contributing](#contributing)
 <!-- END OVERVIEW HOOK -->
 

--- a/modules/templates-ansible/s4hanab4hana-solution/playbook-sap-swpm-install.yml.tftpl
+++ b/modules/templates-ansible/s4hanab4hana-solution/playbook-sap-swpm-install.yml.tftpl
@@ -85,4 +85,4 @@
         name: { role: community.sap_install.sap_swpm }
 
     - name: SAP SWPM Post Install - Enforce Connection Info in hdbuserstore
-      ansible.builtin.shell: "runuser -l {{sap_swpm_sid|lower}}adm -c 'hdbuserstore SET DEFAULT {{ sap_swpm_db_host }}:3{{ sap_swpm_db_instance_nr }}13 {{ sap_swpm_db_schema_abap }} '{{ sap_swpm_db_system_password }}"
+      ansible.builtin.shell: "runuser -l {{sap_swpm_sid|lower}}adm -c 'hdbuserstore SET DEFAULT {{ sap_swpm_db_host }}:3{{ sap_swpm_db_instance_nr }}15 {{ sap_swpm_db_schema_abap }} '{{ sap_swpm_db_system_password }}"

--- a/solutions/e2e/README.md
+++ b/solutions/e2e/README.md
@@ -58,7 +58,7 @@ The end-to-end solution automates the following tasks:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_fullstack"></a> [fullstack](#module\_fullstack) | terraform-ibm-modules/powervs-infrastructure/ibm//modules/powervs-vpc-landing-zone | 4.2.0 |
+| <a name="module_fullstack"></a> [fullstack](#module\_fullstack) | terraform-ibm-modules/powervs-infrastructure/ibm//modules/powervs-vpc-landing-zone | 4.3.0 |
 | <a name="module_sap_system"></a> [sap\_system](#module\_sap\_system) | ../../modules/pi-sap-system-type1 | n/a |
 
 ### Resources

--- a/solutions/e2e/main.tf
+++ b/solutions/e2e/main.tf
@@ -7,7 +7,7 @@
 
 module "fullstack" {
   source  = "terraform-ibm-modules/powervs-infrastructure/ibm//modules/powervs-vpc-landing-zone"
-  version = "4.2.0"
+  version = "4.3.0"
 
   providers = { ibm.ibm-is = ibm.ibm-is, ibm.ibm-pi = ibm.ibm-pi }
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -44,6 +44,10 @@ func setupOptions(t *testing.T, prefix string) *testhelper.TestOptions {
 		Region:             "us-south", // specify default region to skip best choice query
 		DefaultRegion:      "us-south",
 		BestRegionYAMLPath: "../common-dev-assets/common-go-assets/cloudinfo-region-power-prefs.yaml", // specific to powervs zones
+		// temporary workaround for BSS backend issue
+		ImplicitDestroy: []string{
+			"module.fullstack.module.landing_zone.module.landing_zone.ibm_resource_group.resource_groups",
+		},
 	})
 
 	// query for best zone to deploy powervs example, based on current connection count
@@ -57,8 +61,8 @@ func setupOptions(t *testing.T, prefix string) *testhelper.TestOptions {
 
 	options.TerraformVars = map[string]interface{}{
 		// locking into syd04 due to other data center issues
-		//"powervs_zone": "eu-de-2",
-		"powervs_zone":                             options.Region,
+		"powervs_zone": "eu-de-1",
+		//"powervs_zone":                             options.Region,
 		"prefix":                                   options.Prefix,
 		"powervs_resource_group_name":              options.ResourceGroup,
 		"landing_zone_configuration":               "3VPC_RHEL",


### PR DESCRIPTION
### Description

SAP SWPM hdbuserstore config fix . The hdbsuerstore was being set for the wrong DB port. This PR fixes it

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
